### PR TITLE
Fixes .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,5 @@ components
 support
 test
 examples
-rework.js
+/rework.js
 *.sock


### PR DESCRIPTION
Ignoring rework.js also ignores lib/rework.js which breaks the npm module
