### PR TITLE
.import(basePath) plugin to read and inline @imported stylesheets

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,6 +85,7 @@ $ rework -v webkit,moz < my.css > my.reworked.css
   - [references](#references) — add property references support `height: @width` etc
   - [mixin](#mixinobjects) — add custom property logic with mixing
   - [extend](#extend) — add `extend: selector` support
+  - [import](#importpath) — read and inline imported stylesheets
 
 ### .extend()
 
@@ -626,6 +627,39 @@ yields:
   to {
     opacity: 1;
   }
+}
+```
+
+### .import(path)
+  Read and inline imported stylesheets relative to supplied base path.
+
+main.css:
+
+```css
+@import "imported.css"
+
+a {
+  color: yellow
+}
+```
+
+imported.css:
+
+```css
+span {
+  color: red
+}
+```
+
+yields:
+
+```css
+span {
+  color: red
+}
+
+a {
+  color: yellow
 }
 ```
 

--- a/lib/plugins/import.js
+++ b/lib/plugins/import.js
@@ -1,0 +1,76 @@
+
+/**
+ * Module dependencies.
+ */
+
+var css = require('css')
+  , fs = require('fs')
+  , path = require('path')
+  , utils = require('../utils');
+
+/**
+ * Read and inline imported stylesheets.
+ *
+ * main.css:
+ *    @import "imported.css"
+ *
+ *    a {
+ *      color: yellow
+ *    }
+ *
+ * imported.css:
+ *    span {
+ *      color: red
+ *    }
+ *
+ * yields:
+ *
+ *    a {
+ *      color: yellow
+ *    }
+ *
+ *    span {
+ *      color: red
+ *    }
+ */
+
+module.exports = function(basepath) {
+  if (!basepath) basepath = process.cwd();
+
+  return function importPlugin(style, rework) {
+    var rules = [];
+    var files = {};
+
+    visit(style, basepath + path.sep + ".");
+    rework.obj.stylesheet.rules = rules;
+
+    function visit(style, file) {
+      if (files[file] == 'importing')
+        throw new Error('Import cycle detected on ' + file);
+      else if (files[file])
+        return;
+
+      files[file] = 'importing';
+
+      for (var i = 0; i < style.rules.length; i++) {
+        var rule = style.rules[i];
+        if (!rule.import) continue;
+
+        var filename = rule.import.replace(/url\(([^)]+)\)/g, function(_, url) {
+          return url;
+        });
+
+        filename = utils.stripQuotes(filename);
+        if (/^\s*http/.test(filename)) continue;
+        filename = path.resolve(path.dirname(file), filename);
+        if (!fs.existsSync(filename)) continue;
+        style.rules.splice(i--, 1);
+        visit(css.parse(fs.readFileSync(filename, 'utf8')).stylesheet, filename);
+      }
+
+      files[file] = 'imported';
+
+      rules = rules.concat(style.rules);
+    }
+  };
+};

--- a/lib/rework.js
+++ b/lib/rework.js
@@ -104,3 +104,4 @@ exports.at2x = require('./plugins/at2x');
 exports.url = require('./plugins/url');
 exports.ease = require('./plugins/ease');
 exports.vars = require('./plugins/vars');
+exports.import = require('./plugins/import');

--- a/test/fixtures/import-cycle-imported.css
+++ b/test/fixtures/import-cycle-imported.css
@@ -1,0 +1,5 @@
+@import url('import-cycle.css');
+
+div {
+  color: blue;
+}

--- a/test/fixtures/import-cycle.css
+++ b/test/fixtures/import-cycle.css
@@ -1,0 +1,5 @@
+@import url('import-cycle-imported.css');
+
+a {
+  color: blue;
+}

--- a/test/fixtures/import-imported-2.css
+++ b/test/fixtures/import-imported-2.css
@@ -1,0 +1,3 @@
+span {
+  color: yellow;
+}

--- a/test/fixtures/import-imported.css
+++ b/test/fixtures/import-imported.css
@@ -1,0 +1,5 @@
+@import "import-imported-2.css";
+
+div {
+  color: blue;
+}

--- a/test/fixtures/import.css
+++ b/test/fixtures/import.css
@@ -1,0 +1,6 @@
+@import url('import-imported.css');
+@import 'import-imported-2.css';
+
+a {
+  color: blue;
+}

--- a/test/fixtures/import.out.css
+++ b/test/fixtures/import.out.css
@@ -1,0 +1,11 @@
+span {
+  color: yellow
+}
+
+div {
+  color: blue
+}
+
+a {
+  color: blue
+}

--- a/test/rework.js
+++ b/test/rework.js
@@ -230,6 +230,22 @@ describe('rework', function(){
     })
   })
 
+  describe('.import(path)', function(){
+    it('should read imported scripts', function(){
+      rework(fixture('import'))
+        .use(rework.import(__dirname + "/fixtures"))
+        .toString()
+        .should.equal(fixture('import.out'));
+    })
+
+    it('should detect import cycles', function(){
+      (function() {
+        rework(fixture('import-cycle'))
+          .use(rework.import(__dirname + "/fixtures"));
+      }).should.throw();
+    })
+  })
+
   describe('.toString() compress option', function(){
     it('should compress the output', function(){
       rework('body { color: red; }')


### PR DESCRIPTION
Hi,

Created an @import disk read plugin (#24). It just goes in a depth first search and merges the css ast into current one. Not sure if it's the way you'd want to implement though. Feels kinda ugly.
