### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - 0.8

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "mocha": "*",
     "should": "*"
   },
-  "main": "index"
+  "main": "index",
+  "scripts": {
+    "test": "mocha --require should --reporter spec"
+  }
 }


### PR DESCRIPTION
Travis CI is very nice project It will:
- test Rework in different nodejs versions;
- show for new users, that tests are pass now;
- GitHub has integration with Travis CI and will show tests status in pull requests.

You will be need also login on Travis CI (one click via GitHub) and activate rework repo in [Profile](https://travis-ci.org/profile). You can read [Getting started](http://about.travis-ci.org/docs/user/getting-started/).

Also you can add node 0.6 to tests if you want.

Also, maybe it will be better to call scripts via npm from `package.json` scripts?
