### PR TITLE
Adding tidy plugin and tests to remove empty selectors

### DIFF
--- a/examples/tidy.css
+++ b/examples/tidy.css
@@ -1,0 +1,20 @@
+button {
+  padding: 5px 10px;
+  border: 1px solid #eee;
+  border-bottom-color: #ddd;
+}
+
+.green {
+  background: green;
+  padding: 10px 15px
+}
+
+a.join {
+
+}
+
+a.button
+input[type='submit'],
+input[type='button'] {
+
+}

--- a/examples/tidy.js
+++ b/examples/tidy.js
@@ -1,0 +1,9 @@
+
+var rework = require('..')
+  , read = require('fs').readFileSync;
+
+var css = rework(read('examples/tidy.css', 'utf8'))
+  .use(rework.tidy())
+  .toString();
+
+console.log(css);

--- a/lib/plugins/tidy.js
+++ b/lib/plugins/tidy.js
@@ -1,0 +1,24 @@
+/**
+ * Module dependencies.
+ */
+
+var debug = require('debug')('rework:tidy');
+
+/**
+ * Add extension support.
+ */
+
+module.exports = function() {
+  debug('use tidy');
+  return function(style, rework){
+    var i = style.rules.length;
+    for (i; i--;) {
+        var rule = style.rules[i];
+        if (!rule.declarations.length) {
+            debug("Deleting rule:", rule);
+            style.rules.splice(i, 1);
+        }
+    };
+  }
+};
+

--- a/lib/rework.js
+++ b/lib/rework.js
@@ -96,6 +96,7 @@ exports.function = exports.functions = require('./plugins/function');
 exports.prefix = require('./plugins/prefix');
 exports.colors = require('./plugins/colors');
 exports.extend = require('./plugins/extend');
+exports.tidy = require('./plugins/tidy');
 exports.references = require('./plugins/references');
 exports.prefixValue = require('./plugins/prefix-value');
 exports.prefixSelectors = require('./plugins/prefix-selectors');

--- a/rework.js
+++ b/rework.js
@@ -1195,6 +1195,7 @@ exports.mixin = exports.mixins = require('./plugins/mixin');
 exports.prefix = require('./plugins/prefix');
 exports.colors = require('./plugins/colors');
 exports.extend = require('./plugins/extend');
+exports.tidy = require('./plugins/tidy');
 exports.references = require('./plugins/references');
 exports.prefixValue = require('./plugins/prefix-value');
 exports.prefixSelectors = require('./plugins/prefix-selectors');

--- a/test/fixtures/tidy.css
+++ b/test/fixtures/tidy.css
@@ -1,0 +1,21 @@
+
+button {
+  padding: 5px 10px;
+  border: 1px solid #eee;
+  border-bottom-color: #ddd;
+}
+
+.green {
+  background: green;
+  padding: 10px 15px;
+}
+
+a.join {
+
+}
+
+a.button
+input[type='submit'],
+input[type='button'] {
+
+}

--- a/test/fixtures/tidy.extend.css
+++ b/test/fixtures/tidy.extend.css
@@ -1,0 +1,23 @@
+
+button {
+  padding: 5px 10px;
+  border: 1px solid #eee;
+  border-bottom-color: #ddd;
+}
+
+.green {
+  background: green;
+  padding: 10px 15px
+}
+
+a.join {
+  extend: button;
+  extend: .green;
+}
+
+a.button
+input[type='submit'],
+input[type='button'] {
+  extends: button;
+  margin: 2px;
+}

--- a/test/fixtures/tidy.extend.nested.placeholder.css
+++ b/test/fixtures/tidy.extend.nested.placeholder.css
@@ -1,0 +1,22 @@
+
+%dark-button {
+  background: black;
+}
+
+%dark-button:hover {
+  background: rgba(0,0,0,.5);
+}
+
+%dark-button:hover .icon {
+  color: rgba(255,255,255,.5);
+}
+
+.actions a {
+  extend: %dark-button;
+  padding: 5px 10px;
+}
+
+button,
+input[type='submit'] {
+  extend: %dark-button;
+}

--- a/test/fixtures/tidy.extend.nested.placeholder.out.css
+++ b/test/fixtures/tidy.extend.nested.placeholder.out.css
@@ -1,0 +1,21 @@
+.actions a,
+button,
+input[type='submit'] {
+  background: black
+}
+
+.actions a:hover,
+button:hover,
+input[type='submit']:hover {
+  background: rgba(0,0,0,.5)
+}
+
+.actions a:hover .icon,
+button:hover .icon,
+input[type='submit']:hover .icon {
+  color: rgba(255,255,255,.5)
+}
+
+.actions a {
+  padding: 5px 10px
+}

--- a/test/fixtures/tidy.extend.out.css
+++ b/test/fixtures/tidy.extend.out.css
@@ -1,0 +1,21 @@
+button,
+a.join,
+a.button
+input[type='submit'],
+input[type='button'] {
+  padding: 5px 10px;
+  border: 1px solid #eee;
+  border-bottom-color: #ddd
+}
+
+.green,
+a.join {
+  background: green;
+  padding: 10px 15px
+}
+
+a.button
+input[type='submit'],
+input[type='button'] {
+  margin: 2px
+}

--- a/test/fixtures/tidy.out.css
+++ b/test/fixtures/tidy.out.css
@@ -1,0 +1,12 @@
+
+button {
+  padding: 5px 10px;
+  border: 1px solid #eee;
+  border-bottom-color: #ddd;
+}
+
+.green {
+  background: green;
+  padding: 10px 15px;
+}
+

--- a/test/rework.js
+++ b/test/rework.js
@@ -278,4 +278,29 @@ describe('rework', function(){
         .should.equal('body{color:red}');
     })
   })
+
+  describe('.tidy())', function(){
+    it('should tidy output by removing empty selectors', function(){
+      rework(fixture('tidy'))
+      .use(rework.tidy())
+      .toString()
+      .should.equal(fixture('tidy.out'));
+    })
+
+    it('should tidy output after .extend() by removing empty selectors', function(){
+      rework(fixture('tidy.extend'))
+      .use(rework.extend())
+      .use(rework.tidy())
+      .toString()
+      .should.equal(fixture('tidy.extend.out'));
+    })
+
+    it('should tidy output after .extend() nested placeholder by removing empty selectors', function(){
+      rework(fixture('tidy.extend.nested.placeholder'))
+      .use(rework.extend())
+      .use(rework.tidy())
+      .toString()
+      .should.equal(fixture('tidy.extend.nested.placeholder.out'));
+    })
+  })
 })


### PR DESCRIPTION
Simple tidy plugin to remove empty selectors.
This should probably be augmented to do more, but wanted to get a pull request up to start a discussion.

fixes #46
