### PR TITLE
allow vars argument

### DIFF
--- a/lib/plugins/vars.js
+++ b/lib/plugins/vars.js
@@ -24,8 +24,8 @@ var visit = require('../visit');
  *
  */
 
-module.exports = function() {
-  var map = {};
+module.exports = function(map) {
+  if (!map) map = {};
 
   function replace(str) {
     return str.replace(/\bvar\((.*?)\)/g, function(_, name){

--- a/test/fixtures/vars.args.css
+++ b/test/fixtures/vars.args.css
@@ -1,0 +1,17 @@
+div {
+  var-accent-background: linear-gradient(to top, var(main-color), white);
+}
+
+h1 {
+  background-color: var(header-color);
+}
+
+.content {
+  background: var(accent-background) !important;
+}
+
+@media only screen and (min-device-width: 600px) {
+  h2 {
+    color: var(main-color);
+  }
+}

--- a/test/fixtures/vars.args.json
+++ b/test/fixtures/vars.args.json
@@ -1,0 +1,4 @@
+{
+  "header-color": "#06c",
+  "main-color": "#c06"
+}

--- a/test/fixtures/vars.args.out.css
+++ b/test/fixtures/vars.args.out.css
@@ -1,0 +1,17 @@
+div {
+  var-accent-background: linear-gradient(to top, #c06, white)
+}
+
+h1 {
+  background-color: #06c
+}
+
+.content {
+  background: linear-gradient(to top, #c06, white) !important
+}
+
+@media only screen and (min-device-width: 600px) {
+  h2 {
+    color: #c06
+  }
+}

--- a/test/rework.js
+++ b/test/rework.js
@@ -227,6 +227,16 @@ describe('rework', function(){
         .toString()
         .should.equal(fixture('vars.out'));
     })
+
+    it('should add variables from an object', function(){
+      var args = JSON.parse(fs.readFileSync('test/fixtures/vars.args.json', 'utf8'))
+
+      rework(fixture('vars.args'))
+        .vendors(vendors)
+        .use(rework.vars(args))
+        .toString()
+        .should.equal(fixture('vars.args.out'));
+    })
   })
 
   describe('.ease()', function(){


### PR DESCRIPTION
Basically allows `rework.vars()` to have an optional argument `map`. This way you can define your variables in a JSON file instead of in your CSS file. Overwrites the map with additional variables, but I don't think that would be an issue. Tried to change as little of the code as possible.

If you accept:
- Consider removing var support in CSS. Having a single JSON file makes more sense (at least to me).
- Add CLI option `--vars variables.json` (optional if you keep inline var support)
