### PR TITLE
Add Node.js 0.10 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - 0.8
+  - 0.10


### PR DESCRIPTION
Tests in different platforms is a one on major feature of Travis CI. Let’s use it.
