### PR TITLE
.vars(object) and remove var declarations

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -546,7 +546,7 @@ button.round {
 }
 ```
 
-### .vars()
+### .vars(object)
 
   Add variable support. Note that this does not cascade like the CSS variable
   spec does, thus this is _not_ some sort of fallback mechanism, just a useful
@@ -574,15 +574,6 @@ h1 {
   yields:
 
 ```css
-:root {
-  var-header-color: #06c;
-  var-main-color: #c06
-}
-
-div {
-  var-accent-background: linear-gradient(to top, #c06, white)
-}
-
 h1 {
   background-color: #06c
 }
@@ -591,6 +582,33 @@ h1 {
   background: linear-gradient(to top, #c06, white) !important
 }
 ```
+
+  Alternatively, you can define the variables in an object.
+  Note that variables declared in CSS will have precedence.
+
+```js
+  var css = rework(css)
+    .use(vars({
+      'header-color': '#06c',
+      'main-color': '#c06',
+      'accept-background': 'linear-gradient(to top, var(main-color), white)'
+    }))
+    .toString()
+```
+
+Where `css`:
+
+```css
+h1 {
+  background-color: var(header-color);
+}
+
+.content {
+  background: var(accent-background) !important;
+}
+```
+
+will yield the same result as above.
 
 ### .colors()
 

--- a/lib/plugins/vars.js
+++ b/lib/plugins/vars.js
@@ -24,8 +24,8 @@ var visit = require('../visit');
  *
  */
 
-module.exports = function() {
-  var map = {};
+module.exports = function(map) {
+  var map = map || {};
 
   function replace(str) {
     return str.replace(/\bvar\((.*?)\)/g, function(_, name){
@@ -37,18 +37,20 @@ module.exports = function() {
 
   return function vars(style){
     visit.declarations(style, function(declarations, node){
-      // map vars
-      declarations.forEach(function(decl){
-        if (0 != decl.property.indexOf('var-')) return;
-        var name = decl.property.replace('var-', '');
-        map[name] = decl.value;
-      });
+      for (var i = 0; i < declarations.length; i++) {
+        var decl = declarations[i];
+        var property = decl.property;
+        var value = decl.value;
 
-      // substitute values
-      declarations.forEach(function(decl){
-        if (!decl.value.match(/\bvar\(/)) return;
-        decl.value = replace(decl.value);
-      });
+        // map vars
+        if (0 == property.indexOf('var-')) {
+          var name = property.replace('var-', '');
+          map[name] = value;
+          declarations.splice(i--, 1);
+        } else if (value.match(/\bvar\(/)) { // substitute values
+          decl.value = replace(value);
+        }
+      }
     });
   }
 };

--- a/lib/visit.js
+++ b/lib/visit.js
@@ -8,25 +8,36 @@
  * @api private
  */
 
-exports.declarations = function(node, fn){
-  node.rules.forEach(function(rule){
+exports.declarations = function(node, fn) {
+  var rules = node.rules;
+
+  for (var i = 0; i < rules.length; i++) {
+    var rule = rules[i];
+
     // @media etc
     if (rule.rules) {
       exports.declarations(rule, fn);
-      return;
+      if (!rule.rules.length) rules.splice(i--, 1);
+      continue;
     }
 
     // keyframes
-    if (rule.keyframes) {
-      rule.keyframes.forEach(function(keyframe){
-        fn(keyframe.declarations, rule);
-      });
-      return;
+    var keyframes = rule.keyframes
+    if (keyframes) {
+      for (var j = 0; j < keyframes.length; j++) {
+        var decls = keyframes[j].declarations;
+        fn(decls, rule);
+        if (!decls.length) keyframes.splice(j--, 1);
+      }
+      if (!keyframes.length) rules.splice(i--, 1);
+      continue;
     }
 
     // @charset, @import etc
-    if (!rule.declarations) return;
+    var declarations = rule.declarations
+    if (!declarations) continue;
 
-    fn(rule.declarations, node);
-  });
-};
+    fn(declarations, node);
+    if (!declarations.length) rules.splice(i--, 1);
+  }
+}

--- a/test/fixtures/vars.dict.css
+++ b/test/fixtures/vars.dict.css
@@ -1,0 +1,13 @@
+h1 {
+  background-color: var(header-color);
+}
+
+.content {
+  background: var(accent-background) !important;
+}
+
+@media only screen and (min-device-width: 600px) {
+  h2 {
+    color: var(main-color);
+  }
+}

--- a/test/fixtures/vars.dict.json
+++ b/test/fixtures/vars.dict.json
@@ -1,0 +1,5 @@
+{
+  "header-color": "#06c",
+  "main-color": "#c06",
+  "accent-background": "linear-gradient(to top, var(main-color), white)"
+}

--- a/test/fixtures/vars.out.css
+++ b/test/fixtures/vars.out.css
@@ -1,12 +1,3 @@
-:root {
-  var-header-color: #06c;
-  var-main-color: #c06
-}
-
-div {
-  var-accent-background: linear-gradient(to top, #c06, white)
-}
-
 h1 {
   background-color: #06c
 }

--- a/test/rework.js
+++ b/test/rework.js
@@ -227,6 +227,14 @@ describe('rework', function(){
         .toString()
         .should.equal(fixture('vars.out'));
     })
+
+    it('should add variable dictionary support', function(){
+      rework(fixture('vars.dict'))
+        .vendors(vendors)
+        .use(rework.vars(require('./fixtures/vars.dict.json')))
+        .toString()
+        .should.equal(fixture('vars.out'));
+    })
   })
 
   describe('.ease()', function(){


### PR DESCRIPTION
Removes variable declarations in CSS. #51
Allows you to declare variables with an object. #33

Similar to the pull request I previously submitted, but less retarded.

Note: changes `visit.declarations` so that it removes any rules without any declarations.
