### PR TITLE
try/catch plugins unavailable in component

### DIFF
--- a/lib/rework.js
+++ b/lib/rework.js
@@ -105,4 +105,11 @@ exports.at2x = require('./plugins/at2x');
 exports.url = require('./plugins/url');
 exports.ease = require('./plugins/ease');
 exports.vars = require('./plugins/vars');
-exports.inline = require('./plugins/inline');
+
+/**
+ * Try/catch plugins unavailable in component.
+ */
+
+ try {
+  exports.inline = require('./plugins/inline');
+} catch (err) {};


### PR DESCRIPTION
it's not referenced in `component.json`, but inline wouldn't work in the browser anyways
