### PR TITLE
replace extend plugin with rework-inherit

### DIFF
--- a/lib/plugins/extend.js
+++ b/lib/plugins/extend.js
@@ -3,67 +3,17 @@
  */
 
 var debug = require('debug')('rework:extend');
+var inherit = require('rework-inherit');
 
 /**
  * Add extension support.
  */
 
 module.exports = function() {
-  debug('use extend');
-  return function(style, rework) {
-    var map = {};
-    var rules = style.rules.length;
+  debug('use extend')
 
-    for (var j = 0; j < rules; j++) {
-      var rule = style.rules[j];
-      if (!rule || !rule.selectors) return;
-
-      // map selectors
-      rule.selectors.forEach(function(sel, i) {
-        map[sel] = rule;
-        if ('%' == sel[0]) rule.selectors.splice(i, 1);
-      });
-
-      // visit extend: properties
-      visit(rule, map);
-
-      // clean up empty rules
-      if (!rule.declarations.length) {
-        style.rules.splice(j--, 1);
-      }
-    };
-  }
-};
-
-/**
- * Visit declarations and extensions.
- *
- * @param {Object} rule
- * @param {Object} map
- * @api private
- */
-
-function visit(rule, map) {
-  for (var i = 0; i < rule.declarations.length; ++i) {
-    var decl = rule.declarations[i];
-    var key = decl.property;
-    var val = decl.value;
-    if (!/^extends?$/.test(key)) continue;
-
-    var extend = map[val];
-    if (!extend) throw new Error('failed to extend "' + val + '"');
-
-    var keys = Object.keys(map);
-    keys.forEach(function(key) {
-      if (0 != key.indexOf(val)) return;
-      var extend = map[key];
-      var suffix = key.replace(val, '');
-      debug('extend %j with %j', rule.selectors, extend.selectors);
-      extend.selectors = extend.selectors.concat(rule.selectors.map(function(sel) {
-        return sel + suffix;
-      }));
-    });
-
-    rule.declarations.splice(i--, 1);
-  }
+  return inherit({
+    propertyRegExp: /^extends?$/,
+    disableMediaInheritance: true
+  })
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "commander": "1.0.4",
     "color-parser": "0.1.0",
     "mime": "1.2.9",
-    "debug": "*"
+    "debug": "*",
+    "rework-inherit": "0.1.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
replace extend plugin with rework-inherit. not sure if this is exactly what you wanted, but it's easier than maintaining a subset of another library. only downside is that you're downloading extra code since we disable the media query inheritance.

didn't add any additional tests as there are already tests in the library. however, all the current extend plugin issues are now solved.

i can add you as a maintainer if you'd like.
