### PR TITLE
.travis.yml should put quotes around versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.10
+  - "0.8"
+  - "0.10"


### PR DESCRIPTION
otherwise it runs `nvm use 0.1`, though it still works
