### PR TITLE
Fix contain check in prefix-value

### DIFF
--- a/lib/plugins/prefix-value.js
+++ b/lib/plugins/prefix-value.js
@@ -29,7 +29,7 @@ module.exports = function(value, vendors) {
     visit.declarations(style, function(declarations){
       for (var i = 0; i < declarations.length; ++i) {
         var decl = declarations[i];
-        if (!~decl.value.indexOf(value)) continue;
+        if (!contain(decl.value, value)) continue;
 
         // ignore vendor-prefixed properties
         if ('-' == decl.property[0]) continue;
@@ -52,3 +52,12 @@ module.exports = function(value, vendors) {
     });
   }
 };
+
+/**
+ * Check, that `value` contain `word`.
+ */
+function contain(value, word) {
+  var regexp = word.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
+  regexp = new RegExp('(^|\\s)' + regexp + '($|\\s|\\()');
+  return value.match(regexp);
+}

--- a/test/fixtures/prefix-value.css
+++ b/test/fixtures/prefix-value.css
@@ -1,6 +1,6 @@
 button {
   transition: height, transform 2s, width 0.3s linear;
-  background: green;
+  background: url(transform.png)
 }
 
 @media screen {

--- a/test/fixtures/prefix-value.out.css
+++ b/test/fixtures/prefix-value.out.css
@@ -2,7 +2,7 @@ button {
   -webkit-transition: height, -webkit-transform 2s, width 0.3s linear;
   -moz-transition: height, -moz-transform 2s, width 0.3s linear;
   transition: height, transform 2s, width 0.3s linear;
-  background: green
+  background: url(transform.png)
 }
 
 @media screen {


### PR DESCRIPTION
If I add `prefixValue("order")`, `box-sizing: border-box` will be compiled to `box-sizing: b-moz-order-box`, because Rework try to find any `order` symbols in CSS value.

This patch fix CSS value check and `prefixValue` will try to find word, not any letters like `order`.

This fix need to close bug in Autoprefixer: https://github.com/ai/autoprefixer/issues/3
