### PR TITLE
Eased up references regex matching

### DIFF
--- a/lib/plugins/references.js
+++ b/lib/plugins/references.js
@@ -46,7 +46,7 @@ function substitute(declarations) {
 
     if ('comment' == decl.type) continue;
 
-    decl.value = val.replace(/(^| )@([-\w]+)/g, function(_, p, name){
+    decl.value = val.replace(/(^| |,|\()@([-\w]+)/g, function(_, p, name){
       if (null == map[name]) throw new Error('@' + name + ' is not defined in this scope');
       return p + map[name];
     });


### PR DESCRIPTION
I found a need to be able to specify `(` for references when using [rework-shade](https://github.com/james2doyle/rework-shade) so this became possible:

```
li {
  background-color: blue;
  background: linear-gradient(top, lighten(@background-color, 20%), darken(@background-color, 20%))
}
```

I didn't include tests because I wasn't sure how to test this in stock-css (I couldn't think of a time you'd have a property right after a `(`). I wasn't sure if you were okay with having non-stock css in the expected output fixtures. ie. I could write `references.out.css`:

```
li {
 background-color: blue;
 background: linear-gradient(top, lighten(blue, 20%), darken(blue, 20%))
}
```

But I wasn't sure if that would feel dirty to you.

I also added the ability for a `,` leading character (in attempt to avoid running into this problem on something where it's an arg into a function in the future).
