### PR TITLE
add HSV/HSB to RGB function "hsb()"

### DIFF
--- a/lib/plugins/colors.js
+++ b/lib/plugins/colors.js
@@ -32,6 +32,76 @@ module.exports = function() {
       }
 
       return 'rgba(' + args.join(', ') + ')';
+    },
+
+    /**
+     * Converts HSV (HSB) color values to RGB.
+     * Saturation and brightness can be expressed as floats or percentages.
+     *
+     *     color: hsb(220, 45%, .3);
+     *     color: hsb(220deg, 0.45, 30%);
+     *
+     */
+    hsb: function (hue, saturation, value) {
+      var rgb = hsb2rgb(hue, saturation, value);
+      return 'rgb(' + rgb.join(', ') + ')';
+    },
+
+
+    /**
+     * Converts HSV (HSB) color values with alpha specified to RGBa.
+     * Saturation, brightness and alpha can be expressed as floats or
+     * percentages.
+     *
+     *     color: hsba(220, 45%, .3, .4);
+     *     color: hsba(220deg, 0.45, 30%, 40%);
+     *
+     */
+    hsba: function (hue, saturation, value, alpha) {
+      alpha = /%/.test(alpha) ?
+          parseInt(alpha, 10) / 100 :
+          parseFloat(alpha, 10);
+      alpha = String(alpha).replace(/^0+\./, '.');
+
+      var rgb = hsb2rgb(hue, saturation, value);
+      return 'rgba(' + rgb.join(', ') + ', ' + alpha + ')';
     }
   });
 };
+
+
+function hsb2rgb(hue, saturation, value) {
+  hue = (parseInt(hue, 10) || 0) % 360;
+  saturation = /%/.test(saturation) ?
+      parseInt(saturation, 10) / 100 :
+      parseFloat(saturation, 10);
+  value = /%/.test(value) ?
+      parseInt(value, 10) / 100 :
+      parseFloat(value, 10);
+
+  var rgb;
+  if (saturation === 0) {
+    rgb = [value, value, value];
+  } else {
+    var side = hue / 60;
+    var chroma = value * saturation;
+    var x = chroma * (1 - Math.abs(side % 2 - 1));
+    var match = value - chroma;
+
+    switch (Math.floor(side)) {
+    case 0: rgb = [chroma, x, 0]; break;
+    case 1: rgb = [x, chroma, 0]; break;
+    case 2: rgb = [0, chroma, x]; break;
+    case 3: rgb = [0, x, chroma]; break;
+    case 4: rgb = [x, 0, chroma]; break;
+    case 5: rgb = [chroma, 0, x]; break;
+    default: rgb = [0, 0, 0];
+    }
+
+    rgb[0] = Math.round(255 * (rgb[0] + match));
+    rgb[1] = Math.round(255 * (rgb[1] + match));
+    rgb[2] = Math.round(255 * (rgb[2] + match));
+  }
+
+  return rgb;
+}

--- a/test/fixtures/colors.hsb.css
+++ b/test/fixtures/colors.hsb.css
@@ -1,0 +1,24 @@
+
+button {
+  background: hsb(220, .43, .30);
+}
+
+button {
+  border: 1px solid hsb(  220deg  , 0.43, 0.3);
+}
+
+button {
+  background: hsba(220, .43, .30, .4);
+}
+
+button {
+  background: hsba(220, .43, .30, 40%);
+}
+
+button {
+  border: 1px solid hsba(  220deg  , 0.43, 0.3, 0.40);
+}
+
+button {
+  background: linear-gradient(hsb(220, .43, .30), hsb(220, .43, .30));
+}

--- a/test/fixtures/colors.hsb.out.css
+++ b/test/fixtures/colors.hsb.out.css
@@ -1,0 +1,23 @@
+button {
+  background: rgb(44, 55, 77);
+}
+
+button {
+  border: 1px solid rgb(44, 55, 77);
+}
+
+button {
+  background: rgba(44, 55, 77, .4);
+}
+
+button {
+  background: rgba(44, 55, 77, .4);
+}
+
+button {
+  border: 1px solid rgba(44, 55, 77, .4);
+}
+
+button {
+  background: linear-gradient(rgb(44, 55, 77), rgb(44, 55, 77));
+}

--- a/test/rework.js
+++ b/test/rework.js
@@ -82,6 +82,13 @@ describe('rework', function(){
         .toString()
         .should.equal(fixture('colors.out'));
     })
+
+    it('should support hsb(hue, saturation, value)', function(){
+      rework(fixture('colors.hsb'))
+        .use(rework.colors())
+        .toString()
+        .should.equal(fixture('colors.hsb.out'));
+    })
   })
 
   describe('.mixin(obj)', function(){


### PR DESCRIPTION
There are two widely used cylindrical color representations—HSV and HSL. CSS3 only includes HSL but Adobe Photoshop uses HSV (often called HSB) which makes the model chosen for CSS3 pretty much useless for coders.

![screen shot 2013-09-02 at 7 07 51 pm](https://f.cloud.github.com/assets/367262/1070047/bf73ef2e-143d-11e3-9ff6-b9e38a7d8870.png)

The added the  `hsb(hue, saturation, value)` and `hsba(hue, saturation, value, alpha)` functions that convert HSV (Photoshop) values to RGB(a).

```
button {
  background-color: hsb(220, 43%, 30%);
  background-color: hsb(220deg, .43, 0.3);
  background-color: hsb(220deg, .43, 0.3, .4);
  background-color: hsb(220deg, .43, 0.3, 20%);
}
```

It uses `parseInt` and `parseFloat` which makes it possible to use arbitrary suffixes such as `deg` or `%`. The hue is always parsed using `parseInt` while the two 0–100 values are parsed either as ints or as floats depending on whether they end with a percentage sign (int) or not (float).
