### PR TITLE
treat transition-property like transition for value prefixing 

### DIFF
--- a/lib/plugins/prefix-value.js
+++ b/lib/plugins/prefix-value.js
@@ -40,7 +40,7 @@ module.exports = function(value, vendors) {
 
         // vendor prefixed props
         vendors.forEach(function(vendor){
-          var prop = 'transition' == decl.property
+          var prop = 'transition' == decl.property || 'transition-property' == decl.property
             ? vendor + decl.property
             : decl.property;
 

--- a/test/fixtures/prefix-value.css
+++ b/test/fixtures/prefix-value.css
@@ -1,10 +1,12 @@
 button {
   transition: height, transform 2s, width 0.3s linear;
   background: green;
+  transition-property: transform;
 }
 
 @media screen {
   button {
-    transition: transform 1s
+    transition: transform 1s;
+    transition-property: transform;
   }
 }

--- a/test/fixtures/prefix-value.out.css
+++ b/test/fixtures/prefix-value.out.css
@@ -3,6 +3,9 @@ button {
   -moz-transition: height, -moz-transform 2s, width 0.3s linear;
   transition: height, transform 2s, width 0.3s linear;
   background: green;
+  -webkit-transition-property: -webkit-transform;
+  -moz-transition-property: -moz-transform;
+  transition-property: transform;
 }
 
 @media screen {
@@ -10,5 +13,8 @@ button {
     -webkit-transition: -webkit-transform 1s;
     -moz-transition: -moz-transform 1s;
     transition: transform 1s;
+    -webkit-transition-property: -webkit-transform;
+    -moz-transition-property: -moz-transform;
+    transition-property: transform;
   }
 }


### PR DESCRIPTION
The code used to check for the css property 'transition' for css values to prefix. 'transition' however is a shorthand of several properties (including 'transition-property'). This change just makes 'transition-property' follow the same logic as 'transition' for css values to prefix.
