### PR TITLE
Inline source maps as comments

### DIFF
--- a/component.json
+++ b/component.json
@@ -4,7 +4,7 @@
   "description": "CSS manipulations built on CSSOM",
   "keywords": ["css", "manipulation", "preprocess", "transform"],
   "dependencies": {
-    "visionmedia/css": "1.4.4",
+    "visionmedia/css": "1.6.0",
     "visionmedia/debug": "*",
     "visionmedia/rework-visit": "1.0.0",
     "component/color-parser": "0.1.0",

--- a/lib/rework.js
+++ b/lib/rework.js
@@ -27,12 +27,15 @@ exports.properties = require('./properties');
  * Initialize a new stylesheet `Rework` with `str`.
  *
  * @param {String} str
+ * @param {Object} options
  * @return {Rework}
  * @api public
  */
 
-function rework(str) {
-  return new Rework(css.parse(str));
+function rework(str, options) {
+  options = options || {};
+  options.position = true; // we need this for sourcemaps
+  return new Rework(css.parse(str, options));
 }
 
 /**
@@ -83,8 +86,27 @@ Rework.prototype.vendors = function(prefixes){
  */
 
 Rework.prototype.toString = function(options){
-  return css.stringify(this.obj, options);
+  options = options || {};
+  var result = css.stringify(this.obj, options);
+  if (options.sourcemap && !options.sourcemapAsObject) {
+    result = result.code + '\n' + sourcemapToComment(result.map);
+  }
+  return result;
 };
+
+/**
+ * Convert sourcemap to base64-encoded comment
+ *
+ * @param {Object} map
+ * @return {String}
+ * @api private
+ */
+
+function sourcemapToComment(map) {
+  var convertSourceMap = require('convert-source-map');
+  var content = convertSourceMap.fromObject(map).toBase64();
+  return '/*# sourceMappingURL=data:application/json;base64,' + content + ' */';
+}
 
 /**
  * Expose plugins.

--- a/package.json
+++ b/package.json
@@ -2,21 +2,27 @@
   "name": "rework",
   "version": "0.18.3",
   "description": "CSS manipulations built on CSSOM",
-  "keywords": ["css", "manipulation", "preprocess", "transform"],
+  "keywords": [
+    "css",
+    "manipulation",
+    "preprocess",
+    "transform"
+  ],
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "repository": {
     "type": "git",
     "url": "git://github.com/visionmedia/rework.git"
   },
   "dependencies": {
-    "css": "1.4.4",
+    "css": "1.6.0",
     "commander": "1.0.4",
     "color-parser": "0.1.0",
     "hsb2rgb": "1.0.2",
     "mime": "1.2.9",
     "debug": "*",
     "rework-inherit": "0.2.1",
-    "rework-visit": "1.0.0"
+    "rework-visit": "1.0.0",
+    "convert-source-map": "~0.3.1"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/rework.js
+++ b/test/rework.js
@@ -322,4 +322,27 @@ describe('rework', function(){
         .should.equal('body{color:red;}');
     })
   })
+
+  describe('.toString() sourcemap option', function() {
+    it('should inline sourcemap', function() {
+      rework('body { color: red; }')
+        .toString({ compress: true, sourcemap: true })
+        .should.equal(
+          'body{color:red;}' + '\n' +
+          '/*# sourceMappingURL=data:application/json;base64,' +
+               'eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ2VuZXJhdGVkLmNzc' +
+               'yIsInNvdXJjZXMiOlsic291cmNlLmNzcyJdLCJuYW1lcy' +
+               'I6W10sIm1hcHBpbmdzIjoiQUFBQSxLQUFPLFNBQVUifQ== */');
+    })
+  })
+
+  describe('.toString() sourcemapAsObject and sourcemap options', function() {
+    it('should return sourcemap as an object', function() {
+      var result = rework('body { color: red; }')
+        .toString({ compress: true, sourcemap: true, sourcemapAsObject: true });
+      result.code.should.equal('body{color:red;}');
+      result.map.should.have.property('mappings');
+      result.map.mappings.should.equal('AAAA,KAAO,SAAU');
+    })
+  })
 })


### PR DESCRIPTION
I propose inlining source maps as a base64 encoded data uris — that would provide excellent dev experience and doesn't require to serve source maps to browser separately.
