### PR TITLE
add error handling

### DIFF
--- a/lib/rework.js
+++ b/lib/rework.js
@@ -58,7 +58,13 @@ function Rework(obj) {
  */
 
 Rework.prototype.use = function(fn){
-  fn(this.obj.stylesheet, this);
+  try {
+    fn(this.obj.stylesheet, this);
+  } catch (err) {
+    // TODO: grab context for error
+    throw err;
+  }
+
   return this;
 };
 

--- a/test/rework.js
+++ b/test/rework.js
@@ -15,6 +15,18 @@ describe('rework', function(){
     })
   })
 
+  describe('.use(fn)', function(){
+    it('should catch errors', function(done){
+      try {
+        rework('body { color: red; }')
+          .use(function(){ throw new Error; });
+      } catch (err) {
+        // TODO: add testing for context
+        done();
+      }
+    })
+  })
+
   describe('visitor', function(){
     it('should work with charset, import, etc', function(){
       rework(fixture('charset'))


### PR DESCRIPTION
dunno how we want to handle this, but i figure rework should just make it available, not actually do anything? up to plugins to properly attach the line number and shit imo

actually, in addition to this, if we wanted there could be a `rework.error(dec, message)` helper to make it even easier
