### PR TITLE
prefix-selectors: add support for :root pseudo-class

### DIFF
--- a/lib/plugins/prefix-selectors.js
+++ b/lib/plugins/prefix-selectors.js
@@ -19,6 +19,8 @@ module.exports = function(str) {
     style.rules = style.rules.map(function(rule){
       if (!rule.selectors) return rule;
       rule.selectors = rule.selectors.map(function(selector){
+        if (':root' == selector) return str;
+        selector = selector.replace(/^\:root\s?/, '');
         return str + ' ' + selector;
       });
       return rule;

--- a/test/fixtures/prefix-selectors-root.css
+++ b/test/fixtures/prefix-selectors-root.css
@@ -1,0 +1,11 @@
+:root {
+  bar: 'baz';
+}
+
+:root foo {
+  color: #f00;
+}
+
+bar {
+  font-family: "Wingdings";
+}

--- a/test/fixtures/prefix-selectors-root.out.css
+++ b/test/fixtures/prefix-selectors-root.out.css
@@ -1,0 +1,11 @@
+#dialog {
+  bar: 'baz';
+}
+
+#dialog foo {
+  color: #f00;
+}
+
+#dialog bar {
+  font-family: "Wingdings";
+}

--- a/test/rework.js
+++ b/test/rework.js
@@ -219,6 +219,12 @@ describe('rework', function(){
         .toString()
         .should.equal(fixture('prefix-selectors.out'));
     })
+    it('should use the prefix as the :root pseudo-class', function(){
+      rework(fixture('prefix-selectors-root'))
+        .use(rework.prefixSelectors('#dialog'))
+        .toString()
+        .should.equal(fixture('prefix-selectors-root.out'));
+    })
   })
 
   describe('.url(fn)', function(){


### PR DESCRIPTION
In our modular component CSS, we've been having trouble referencing the root
element of our CSS when used in conjunction with the `prefixSelectors()`
plugin.

A clever solution for this is to re-purpose the `:root` pseudo-class from
CSS3 to mean "the prefixed selector" when encountered, which would give us
a nice way to reference that root element with a clean semantic syntax.

http://dev.w3.org/csswg/selectors3/#root-pseudo
https://developer.mozilla.org/en-US/docs/Web/CSS/:root
