### PR TITLE
Unignore /rework.js so it's in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,4 @@ components
 support
 test
 examples
-/rework.js
 *.sock


### PR DESCRIPTION
When using rework both on server and client for an app, it would be great to only have to install the npm package and serve the browser version of `rework.js` from `node_modules/rework/`
