### PR TITLE
Add component dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
+NODE_BIN=node_modules/.bin
+MOCHA=$(NODE_BIN)/mocha
+COMPONENT=$(NODE_BIN)/component
 
 rework.js:
-	@component install
-	@component build --standalone rework --out . --name rework
+	@$(COMPONENT) install
+	@$(COMPONENT) build --standalone rework --out . --name rework
 
 test:
-	@./node_modules/.bin/mocha \
-		--require should
+	@$(MOCHA) --require should
 
 clean:
 	rm -f rework.js

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "should": "*"
+    "should": "*",
+    "component": "~0.19.9"
   },
   "main": "index",
   "scripts": {


### PR DESCRIPTION
People without a globally installed component get a make error.
