### PR TITLE
Depend directly on 'css-parse' and 'css-stringify'

### DIFF
--- a/lib/rework.js
+++ b/lib/rework.js
@@ -3,7 +3,10 @@
  * Module dependencies.
  */
 
-var css = require('css');
+var css = {
+  parse: require('css-parse'),
+  stringify: require('css-stringify')
+};
 
 /**
  * Expose `rework`.
@@ -24,7 +27,7 @@ exports.visit = require('./visit');
 exports.__defineGetter__('properties', function () {
   console.warn('rework.properties has been removed.');
   return [];
-})
+});
 
 /**
  * Initialize a new stylesheet `Rework` with `str`.

--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
     "url": "git://github.com/reworkcss/rework.git"
   },
   "dependencies": {
-    "css": "1.6.0",
     "color-parser": "0.1.0",
     "hsb2rgb": "1.0.2",
     "mime": "1.2.11",
     "debug": "*",
     "rework-inherit": "~0.2.1",
     "rework-visit": "1.0.0",
-    "convert-source-map": "~0.3.1"
+    "convert-source-map": "~0.3.1",
+    "css-parse": "^1.7.0",
+    "css-stringify": "^1.4.1"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Less annoying than having to update 'css' every time we want to make use of a new version of either of these modules.
