### PR TITLE
Depend on 'css' 2.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,9 @@
  * Module dependencies.
  */
 
-var parse = require('css-parse');
-var stringify = require('css-stringify');
+var css = require('css');
+var parse = css.parse;
+var stringify = css.stringify;
 
 /**
  * Expose `rework`.

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "index.js"
   ],
   "dependencies": {
-    "css-parse": "^1.7.0",
-    "css-stringify": "^1.4.1",
+    "css": "^2.0.0",
     "mime": "^1.2.11",
     "debug": "*",
     "convert-source-map": "^0.3.3"


### PR DESCRIPTION
Causes a couple of source map tests to fail. Does anything look wrong to you @conradz or @lydell? Or is this just a case of updated the expected result to match the new output?

```
  1) rework .toString() sourcemap option should inline sourcemap:

      AssertionError: expected 'body{color:red;}\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjpudWxsLCJzb3VyY2VzIjpbInNvdXJjZS5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsS0FBTyIsInNvdXJjZXNDb250ZW50IjpbImJvZHkgeyBjb2xvcjogcmVkOyB9Il19 */' to be 'body{color:red;}\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ2VuZXJhdGVkLmNzcyIsInNvdXJjZXMiOlsic291cmNlLmNzcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxLQUFPLFNBQVUifQ== */'
      + expected - actual

      +"body{color:red;}\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ2VuZXJhdGVkLmNzcyIsInNvdXJjZXMiOlsic291cmNlLmNzcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxLQUFPLFNBQVUifQ== */"
      -"body{color:red;}\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjpudWxsLCJzb3VyY2VzIjpbInNvdXJjZS5jc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsS0FBTyIsInNvdXJjZXNDb250ZW50IjpbImJvZHkgeyBjb2xvcjogcmVkOyB9Il19 */"


  2) rework .toString() sourcemapAsObject and sourcemap options should return sourcemap as an object:

      AssertionError: expected 'AAAA,KAAO' to be 'AAAA,KAAO,SAAU'
      + expected - actual

      +"AAAA,KAAO,SAAU"
      -"AAAA,KAAO"
```
