### PR TITLE
Update readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,42 +1,49 @@
 # rework [![Build Status](https://travis-ci.org/reworkcss/rework.png)](https://travis-ci.org/reworkcss/rework)
 
-CSS manipulations built on [css](https://github.com/reworkcss/css), allowing
+CSS manipulations built on [`css`](https://github.com/reworkcss/css), allowing
 you to automate vendor prefixing, create your own properties, inline images,
 anything you can imagine!
 
-Please refer to [css](https://github.com/reworkcss/css) for AST documentation
+Please refer to [`css`](https://github.com/reworkcss/css) for AST documentation
 and to report parser/stringifier issues.
 
 ## Installation
 
-```
-$ npm install rework
-```
+    $ npm install rework
 
-## Built with rework
+## Usage
 
-- [styl](https://github.com/visionmedia/styl) - CSS preprocessor built on Rework
-- [rework-pure-css](https://github.com/ianstormtaylor/rework-pure-css) - bleeding-edge, spec-compliant CSS
-- [rework-suit](https://github.com/suitcss/rework-suit) - CSS preprocessor for SUIT
-- [resin](https://github.com/topcoat/resin) - Opinionated CSS preprocessor for Topcoat
-- [Myth] (https://github.com/segmentio/myth) -  CSS preprocessor built using Rework
+```js
+var rework = require('rework');
+var pluginA = require('pluginA');
+var pluginB = require('pluginB');
+
+rework('body { font-size: 12px; }', { source: 'source.css' })
+  .use(pluginA)
+  .use(pluginB)
+  .toString({ sourcemap: true })
+```
 
 ## API
 
-### rework(css)
+### rework(code, [options])
 
-Return a new `Rework` instance for the given string of `css`.
+Accepts a CSS string and returns a new `Rework` instance. The `options` are
+passed directly to `css.parse`.
 
 ### Rework#use(fn)
 
 Use the given plugin `fn`. A rework "plugin" is simply a function accepting the
-stylesheet object and `Rework` instance.
+stylesheet root node and the `Rework` instance.
 
-### Rework#toString(options)
+### Rework#toString([options])
 
-Return the string representation of the manipulated css. Optionally you may
-compress the output with `.toString({ compress: true })` and/or generate an
-inline source map with `.toString({ sourcemap: true })`
+Returns the string representation of the manipulated CSS. The `options` are
+passed directly to `css.stringify`.
+
+Unlike `css.stringify`, if you pass `sourcemap: true` a string will still be
+returned, with the source map inlined. Also use `sourcemapAsObject: true` if
+you want the `css.stringify` return value.
 
 ## Plugins
 
@@ -45,25 +52,33 @@ plugins](https://www.npmjs.org/search?q=rework) available on npm.
 
 Plugins of particular note:
 
-- [at2x](https://github.com/reworkcss/rework-plugin-at2x/) — serve high resolution images
-- [calc](https://github.com/reworkcss/rework-calc) - resolve simple `calc()` expressions
-- [colors](https://github.com/reworkcss/rework-plugin-colors/) — add colour helpers like `rgba(#fc0, .5)`
-- [ease](https://github.com/reworkcss/rework-plugin-ease/) — several additional easing functions
-- [extend](https://github.com/reworkcss/rework-inherit/) — add `extend: selector` support
-- [function](https://github.com/reworkcss/rework-plugin-function/) — Add user-defined CSS functions
-- [import](https://github.com/reworkcss/rework-import) - read and inline css via `@import`
-- [inline](https://github.com/reworkcss/rework-plugin-inline) - inline assets as dataURI with base64 encoding
-- [mixin](https://github.com/reworkcss/rework-plugin-mixin/) — add custom property logic with mixing
-- [references](https://github.com/reworkcss/rework-plugin-references/) — add property references support `height: @width` etc
-- [significant whitespace](https://github.com/reworkcss/css-whitespace) - nested and indented syntax like Stylus and SASS
-- [url](https://github.com/reworkcss/rework-plugin-url/) - rewrite `url()`s with a given function
-- [variables](https://github.com/reworkcss/rework-vars/) - W3C-style variables
+- [at2x](https://github.com/reworkcss/rework-plugin-at2x/) – serve high resolution images
+- [calc](https://github.com/reworkcss/rework-calc) – resolve simple `calc()` expressions
+- [colors](https://github.com/reworkcss/rework-plugin-colors/) – add colour helpers like `rgba(#fc0, .5)`
+- [ease](https://github.com/reworkcss/rework-plugin-ease/) – several additional easing functions
+- [extend](https://github.com/reworkcss/rework-inherit/) – `extend: selector` support
+- [function](https://github.com/reworkcss/rework-plugin-function/) – user-defined CSS functions
+- [import](https://github.com/reworkcss/rework-import) – read and inline css via `@import`
+- [inline](https://github.com/reworkcss/rework-plugin-inline) – inline assets as dataURI with base64 encoding
+- [mixin](https://github.com/reworkcss/rework-plugin-mixin/) – custom property logic with mixins
+- [references](https://github.com/reworkcss/rework-plugin-references/) – property references like `height: @width`
+- [url](https://github.com/reworkcss/rework-plugin-url/) – rewrite `url()`s with a given function
+- [variables](https://github.com/reworkcss/rework-vars/) – W3C-style variables
+
+## Built with rework
+
+- [styl](https://github.com/visionmedia/styl)
+- [rework-pure-css](https://github.com/ianstormtaylor/rework-pure-css)
+- [rework-suit](https://github.com/suitcss/rework-suit)
+- [resin](https://github.com/topcoat/resin)
+- [Myth](https://github.com/segmentio/myth)
 
 ## License
 
 (The MIT License)
 
 Copyright (c) 2012 - 2013 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2014 Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the 'Software'), to deal in


### PR DESCRIPTION
- Sync it with the reworkcss/css readme.
- Put the "Built with rework" section last.
- Remove the "descriptions" of the "Built with rework" entries.
- Explicitly say that `options` are passed to `css`.
- Document the `sourcemapAsObject` option.
- Minor whitespace and punctuation fixes.
