### PR TITLE
Add tests for the .use() function

### DIFF
--- a/test/rework.js
+++ b/test/rework.js
@@ -2,6 +2,19 @@ var rework = require('..');
 
 describe('rework', function() {
 
+  describe('.use() call function', function() {
+    it('should call the plugin function', function() {
+      var r = rework('body { color: red; }');
+      var called = false;
+      var result = r.use(function(sheet, instance) {
+        sheet.should.have.property('rules');
+        instance.should.equal(r);
+      });
+
+      result.should.equal(r);
+    });
+  });
+
   describe('.toString() compress option', function() {
     it('should compress the output', function() {
       rework('body { color: red; }')


### PR DESCRIPTION
This adds tests for the `.use()` function, which is pretty core to rework's use, so I think it should be tested.
