### PR TITLE
Cleanup dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
  */
 
 var css = require('css');
+var convertSourceMap = require('convert-source-map');
 var parse = css.parse;
 var stringify = css.stringify;
 
@@ -76,7 +77,6 @@ Rework.prototype.toString = function(options){
  */
 
 function sourcemapToComment(map) {
-  var convertSourceMap = require('convert-source-map');
   var content = convertSourceMap.fromObject(map).toBase64();
   return '/*# sourceMappingURL=data:application/json;base64,' + content + ' */';
 }

--- a/package.json
+++ b/package.json
@@ -8,13 +8,11 @@
   ],
   "dependencies": {
     "css": "^2.0.0",
-    "mime": "^1.2.11",
-    "debug": "*",
     "convert-source-map": "^0.3.3"
   },
   "devDependencies": {
-    "mocha": "*",
-    "should": "*"
+    "mocha": "^1.20.1",
+    "should": "^4.0.4"
   },
   "scripts": {
     "test": "mocha --require should --reporter spec"


### PR DESCRIPTION
- Removes the unused `mime` and `debug` dependencies from the package
- Moves `convert-source-map` dependency to the top of the file to make the dependency obvious
- Specify the `mocha` and `should` dev dependency versions so that new breaking releases do not break the tests
