### PR TITLE
Support for asynchronous plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var css = require('css');
 var convertSourceMap = require('convert-source-map');
 var parse = css.parse;
 var stringify = css.stringify;
+var Promise = require('bluebird');
 
 /**
  * Expose `rework`.
@@ -60,15 +61,12 @@ Rework.prototype.use = function(fn){
  *
  */
 
-Rework.prototype.then = function(fn) {
+Rework.prototype.consume = function(fn) {
   var self = this;
-  var promise = fn(this);
-
-  if (!promise) {
-    throw new Error('Rework#then must consume a Function which returns Promise');
-  }
-
-  return promise.then(function() { return self; }, function(err) { throw err; });
+  this._promise = Promise.resolve(this._promise).then(function() {
+    return Promise.resolve(fn(self)).then(function() {return self;})
+  });
+  return this;
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ var css = require('css');
 var convertSourceMap = require('convert-source-map');
 var parse = css.parse;
 var stringify = css.stringify;
+var Promise = require('bluebird');
+var clone = require('clone');
 
 /**
  * Expose `rework`.
@@ -49,6 +51,25 @@ function Rework(obj) {
 Rework.prototype.use = function(fn){
   fn(this.obj.stylesheet, this);
   return this;
+};
+
+/**
+ * Use the given async plugin `fn(style)`.
+ *
+ * @param {Function} fn
+ * @return {Promise}
+ * @api public
+ */
+
+Rework.prototype.then = function(fn) {
+  var self = this;
+  var style = clone(self.obj.stylesheet, true);
+  return fn(style).then(
+    function(newStyle) {
+      self.obj.stylesheet = newStyle;
+      return newStyle;
+    }, function(error) { throw error; }
+  );
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@ var css = require('css');
 var convertSourceMap = require('convert-source-map');
 var parse = css.parse;
 var stringify = css.stringify;
-var Promise = require('bluebird');
-var clone = require('clone');
 
 /**
  * Expose `rework`.
@@ -59,21 +57,18 @@ Rework.prototype.use = function(fn){
  * @param {Function} fn
  * @return {Promise}
  * @api public
+ *
  */
 
 Rework.prototype.then = function(fn) {
   var self = this;
-  var style = clone(self.obj.stylesheet, true);
-  var promise = fn(style);
+  var promise = fn(this);
 
-  if (promise && promise.then) {
-    return promise.then(function(newStyle) {
-      self.obj.stylesheet = newStyle;
-      return newStyle;
-    }, function(error) { throw error; });
-  } else {
-    return Promise.resolve();
+  if (!promise) {
+    throw new Error('Rework#then must consume a Function which returns Promise');
   }
+
+  return promise.then(function() { return self; }, function(err) { throw err; });
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -64,12 +64,16 @@ Rework.prototype.use = function(fn){
 Rework.prototype.then = function(fn) {
   var self = this;
   var style = clone(self.obj.stylesheet, true);
-  return fn(style).then(
-    function(newStyle) {
+  var promise = fn(style);
+
+  if (promise && promise.then) {
+    return promise.then(function(newStyle) {
       self.obj.stylesheet = newStyle;
       return newStyle;
-    }, function(error) { throw error; }
-  );
+    }, function(error) { throw error; });
+  } else {
+    return Promise.resolve();
+  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -7,10 +7,8 @@
     "index.js"
   ],
   "dependencies": {
-    "clone": "^0.2.0",
     "convert-source-map": "^0.3.3",
-    "css": "^2.0.0",
-    "bluebird": "^2.8.2"
+    "css": "^2.0.0"
   },
   "devDependencies": {
     "mocha": "^1.20.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "index.js"
   ],
   "dependencies": {
+    "bluebird": "^2.9.3",
     "convert-source-map": "^0.3.3",
     "css": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "dependencies": {
     "clone": "^0.2.0",
     "convert-source-map": "^0.3.3",
-    "css": "^2.0.0"
+    "css": "^2.0.0",
+    "bluebird": "^2.8.2"
   },
   "devDependencies": {
     "mocha": "^1.20.1",
-    "should": "^4.0.4",
-    "bluebird": "^2.8.2"
+    "should": "^4.0.4"
   },
   "scripts": {
     "test": "mocha --require should --reporter spec"

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
     "index.js"
   ],
   "dependencies": {
-    "css": "^2.0.0",
-    "convert-source-map": "^0.3.3"
+    "clone": "^0.2.0",
+    "convert-source-map": "^0.3.3",
+    "css": "^2.0.0"
   },
   "devDependencies": {
     "mocha": "^1.20.1",
-    "should": "^4.0.4"
+    "should": "^4.0.4",
+    "bluebird": "^2.8.2"
   },
   "scripts": {
     "test": "mocha --require should --reporter spec"

--- a/test/rework.js
+++ b/test/rework.js
@@ -1,4 +1,5 @@
 var rework = require('..');
+var Promise = require('bluebird');
 
 describe('rework', function() {
 
@@ -12,6 +13,35 @@ describe('rework', function() {
       });
 
       result.should.equal(r);
+    });
+  });
+
+  describe('.then() call function', function() {
+    it('should call the plugin function', function(done) {
+      var r = rework('body { color: red; }');
+      var called = false;
+      var result = r
+      .then(function(sheet) {
+        sheet.rules[0].selectors = ['.cls'];
+
+        // Check whether we're working with copies.
+        sheet.should.not.equal(r.obj.stylesheet);
+
+        return new Promise(function(resolve, reject) {
+          resolve(sheet);
+        });
+      })
+      .then(function(sheet) {
+        sheet.rules[0].selectors.push('.cls2');
+        return new Promise(function(resolve, reject) {
+          resolve(sheet);
+        });
+      })
+      .then(function(sheet) {
+        var result = r.toString({compress: true});
+        result.should.equal('.cls,.cls2{color:red;}');
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
Hey!

This PR adds support for async plugins. This is very useful feature because of performance. Node is great because of async IO, after all. I've switched [rework-import](https://github.com/paulmillr/rework-import) to it already.

The API:

``` javascript
rework
  .use(colorsPlugin())
  .consume(reworkImport({path: '.'}))
  .consume(rewrite())
  .consume(function() {
    console.log('Result', rework);
  });

```

I'll add documentation and fix tests in a bit.
